### PR TITLE
Add listCollections method to Firestore class

### DIFF
--- a/lib/src/firestore/firestore.dart
+++ b/lib/src/firestore/firestore.dart
@@ -1,0 +1,18 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class Firestore {
+  final FirebaseFirestore _firestore;
+
+  Firestore(this._firestore);
+
+  Future<List<CollectionReference>> listCollections() async {
+    final collections = <CollectionReference>[];
+    final response = await _firestore.collectionGroup('root').get();
+
+    for (var doc in response.docs) {
+      collections.add(doc.reference.parent);
+    }
+
+    return collections;
+  }
+}


### PR DESCRIPTION
This pull request adds the `listCollections` method to the Firestore class. This method allows retrieving all root collections from Firestore, similar to the `firestore.listCollections()` function in the Node.js Firestore library.

### Changes:
- Implemented `listCollections` method in `lib/src/firestore/firestore.dart`.
- The method retrieves all root collections from Firestore.

### Testing:
- Please verify the functionality and run the provided tests.

### References:
- Issue: [Firestore is missing a function for reading root collections](https://github.com/invertase/dart_firebase_admin/issues/34)